### PR TITLE
chore: Update to Minecraft 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,18 @@ org.gradle.jvmargs=-Xmx1G
 
 # https://fabricmc.net/develop/
 # Fabric Properties
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.13
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
+loader_version=0.16.14
 
 # Fabric API
-fabric_version=0.119.9+1.21.5
+fabric_version=0.129.0+1.21.8
 
 # Mod Properties
-mod_version = 1.2.3
+mod_version = 1.2.3+1.21.8
 maven_group = net.just_s
 archives_base_name = survival-debug-mod
+
+
+
+#loom_version=1.11-SNAPSHOT


### PR DESCRIPTION
There were no code changes needed, but something in the mapping of vanilla methods have changed, so a recompile did the trick. It might be that the change happened somewhere in 1.21.6 or 1.21.7 instead, I did not check this but only "scratched my itch".